### PR TITLE
Also compare panicking behavior

### DIFF
--- a/src/tests/hash_map.rs
+++ b/src/tests/hash_map.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::find_map)]
 #![allow(clippy::must_use_candidate)]
-#![feature(shrink_to)]
+//#![feature(shrink_to)]
 
 #[macro_use]
 extern crate derive_arbitrary;
@@ -92,9 +92,9 @@ where
         pos.map(|idx| self.data.swap_remove(idx).1)
     }
 
-    pub fn shrink_to(&mut self, min_capacity: usize) {
-        self.data.shrink_to(std::cmp::min(self.data.capacity(), std::cmp::max(min_capacity, self.data.len())));
-    }
+    // pub fn shrink_to(&mut self, min_capacity: usize) {
+    //     self.data.shrink_to(std::cmp::min(self.data.capacity(), std::cmp::max(min_capacity, self.data.len())));
+    // }
 
     pub fn shrink_to_fit(&mut self) {
         self.data.shrink_to_fit();
@@ -149,7 +149,7 @@ arbitrary_stateful_operations! {
             fn get_mut(&mut self, k: &K) -> Option<&mut V>;
             fn insert(&mut self, k: K, v: V) -> Option<V>;
             fn remove(&mut self, k: &K) -> Option<V>;
-            fn shrink_to(&mut self, min_capacity: usize);
+            //fn shrink_to(&mut self, min_capacity: usize);
             fn shrink_to_fit(&mut self);
         }
 


### PR DESCRIPTION
I've attempted to implement #2 but ended up in a weird lifetime hell, and could not resolve it by myself. I'm opening a WIP PR so that someone else might get a better starting point if they try to implement this.

The error is:
```
error[E0495]: cannot infer an appropriate lifetime for autoref due to conflicting requirements
   --> src/tests/index_map.rs:168:16
    |
168 |             fn values_mut(&mut self) -> impl Iterator<Item = &mut V>;
    |                ^^^^^^^^^^
    |
note: first, the lifetime cannot outlive the lifetime `'_` as defined on the body at 135:1...
   --> src/tests/index_map.rs:135:1
    |
135 |   arbitrary_stateful_operations! {
    |  _-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
136 | |     model = ModelHashMap<K, V>,
137 | |     tested = IndexMap<K, V>,
138 | |
...   |
170 | |     }
171 | | }
    | |_- in this macro invocation
note: ...so that closure can access `model`
   --> src/tests/index_map.rs:135:1
    |
135 | / arbitrary_stateful_operations! {
136 | |     model = ModelHashMap<K, V>,
137 | |     tested = IndexMap<K, V>,
138 | |
...   |
170 | |     }
171 | | }
    | | ^ in this macro invocation
    | |_|
    | 
note: but, the lifetime must be valid for the call at 135:1...
   --> src/tests/index_map.rs:135:1
    |
135 | / arbitrary_stateful_operations! {
136 | |     model = ModelHashMap<K, V>,
137 | |     tested = IndexMap<K, V>,
138 | |
...   |
170 | |     }
171 | | }
    | | ^ in this macro invocation
    | |_|
    | 
note: ...so type `std::result::Result<impl std::iter::Iterator, std::boxed::Box<(dyn std::any::Any + std::marker::Send + 'static)>>` of expression is valid during the expression
   --> src/tests/index_map.rs:135:1
    |
135 | / arbitrary_stateful_operations! {
136 | |     model = ModelHashMap<K, V>,
137 | |     tested = IndexMap<K, V>,
138 | |
...   |
170 | |     }
171 | | }
    | | ^ in this macro invocation
    | |_|
    | 
```